### PR TITLE
Silence codecvt deprecation warnings when building with NDK 28

### DIFF
--- a/support-lib/jni/djinni_support.cpp
+++ b/support-lib/jni/djinni_support.cpp
@@ -435,8 +435,11 @@ void JniLocalScope::_popLocalFrame(JNIEnv* const env, jobject returnRef) {
     env->PopLocalFrame(returnRef);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 using WcharConverter = std::wstring_convert<std::codecvt_utf16<wchar_t, 0x10ffff, std::codecvt_mode::little_endian>>;
 using Utf8Converter = std::wstring_convert<std::codecvt_utf8_utf16<char16_t, 0x10ffff, std::codecvt_mode::little_endian>, char16_t>;
+
 
 jstring jniStringFromWString(JNIEnv * env, const std::wstring & str) {
     std::string u16 = WcharConverter{}.to_bytes(str);
@@ -472,6 +475,8 @@ std::string jniUTF8FromString(JNIEnv* env, const jstring jstr) {
     env->ReleaseStringChars(jstr, u16);
     return out;
 }
+
+#pragma clang diagnostic pop
 
 DJINNI_WEAK_DEFINITION
 void jniSetPendingFromCurrent(JNIEnv * env, const char * ctx) noexcept {


### PR DESCRIPTION
According to these sources:
https://stackoverflow.com/questions/42946335/deprecated-header-codecvt-replacement
https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0618r0.html

We should not be in a hurry to replace the deprecated standard library APIs, and we're actually not using the affected functions anyway, as we don't have wstrings that need to be passed across the JNI boundaries.

For now we're just going to silence the warnings.